### PR TITLE
Content Parser cannot transform codes when the repo contains a syntax-check error

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ with a few optional parameters.
 ```commandline
 $ ansible-content-parser --help
 usage: ansible-content-parser [-h] [--config-file CONFIG_FILE]
-                              [--profile {min,basic,moderate,safety,shared,production}] [--skip-ansible-lint] [-v]
-                              [--source-license SOURCE_LICENSE] [--source-description SOURCE_DESCRIPTION]
-                              [--repo-name REPO_NAME] [--repo-url REPO_URL]
+                              [--profile {min,basic,moderate,safety,shared,production}] [--skip-transform]
+                              [--skip-ansible-lint] [--no-exclude] [-v] [--source-license SOURCE_LICENSE]
+                              [--source-description SOURCE_DESCRIPTION] [--repo-name REPO_NAME] [--repo-url REPO_URL]
                               source output
 
 Parse Ansible files in the given repository by running ansible-lint and generate a training dataset for Ansible
@@ -52,6 +52,8 @@ options:
   --skip-transform      Skip the transform step of ansible-lint. If this option is not specified, ansible-lint is
                         executed with the --write option and files are transformed according to the rules specified.
   --skip-ansible-lint   Skip the execution of ansible-lint.
+  --no-exclude          Do not rerun ansible-lint with excluding files that caused syntax check errors. If one or more
+                        syntax check errors were found, execution fails without generating the training dataset.
   -v, --verbose         Explain what is being done
   --source-license SOURCE_LICENSE
                         Specify the license that will be included in the training dataset.
@@ -140,7 +142,7 @@ in the Content Parser run.
 `lint-result.json` is created in the `metadata` subdirectory
 as the result of the execution
 of `ansible-content-parser`. The file contains a dictionary, which
-has one key/value pairs:
+has two key/value pairs:
 
 1. `files` This is for the list of files that were found
    in the execution. The format of each file entry is explained below.
@@ -176,6 +178,15 @@ Following shows an example of a file entry:
   "updated": false
 }
 ```
+
+2.  `excluded` This is for the list of file paths, which were excluded in the second `ansible-lint`
+    execution because syntax check errors were found in those files on the first execution.
+    The files included in the list will not appear in the entries associated with the `files` key.
+
+        - **Note:** If `ansible-content-parser` is executed with the `--no-exclude` option, the second execution
+
+    does not occur even if syntax check errors were found on the first execution and
+    the training dataset will not be created.
 
 #### sarif.json
 

--- a/src/ansible_content_parser/__main__.py
+++ b/src/ansible_content_parser/__main__.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import sys
 import tarfile
+import typing
 import zipfile
 
 from collections.abc import Generator
@@ -47,7 +48,7 @@ def pushd(new_dir: str) -> Generator[None, None, None]:
 def execute_ansiblelint(
     argv: list[str],
     work_dir: str,
-) -> dict[str, list[LintableDict]]:
+) -> dict[str, typing.Any]:
     """Execute ansible-lint."""
     with pushd(work_dir):
         # Clear root logger handlers as ansible-lint adds one without checking existing ones.
@@ -86,6 +87,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--skip-ansible-lint",
         action="store_true",
         help="Skip the execution of ansible-lint.",
+    )
+    parser.add_argument(
+        "--no-exclude",
+        action="store_true",
+        help="Do not rerun ansible-lint with excluding files that caused syntax check errors. If one or more syntax "
+        "check errors were found, execution fails without generating the training dataset.",
     )
     parser.add_argument(
         "-v",
@@ -276,24 +283,7 @@ def main() -> None:
         update_argv(argv, args)
 
         try:
-            # Execute ansible-lint and create metadata files.
-            if not args.skip_ansible_lint:
-                serializable_result = execute_ansiblelint(
-                    argv,
-                    str(repository_path),
-                )
-                lint_result_path = metadata_path / "lint-result.json"
-                with lint_result_path.open(
-                    "w",
-                    encoding="utf-8",
-                ) as f:
-                    f.write(json.dumps(serializable_result))
-
-            generate_report(
-                "" if args.skip_ansible_lint else str(lint_result_path),
-                sarif_file,
-                args,
-            )
+            execute_lint_step(args, argv, metadata_path, repository_path, sarif_file)
         except Exception:
             _logger.exception("An exception was thrown while running ansible-lint.")
             sys.exit(1)
@@ -311,6 +301,77 @@ def main() -> None:
         raise
 
     sys.exit(return_code)
+
+
+def execute_lint_step(
+    args: argparse.Namespace,
+    argv: list[str],
+    metadata_path: Path,
+    repository_path: Path,
+    sarif_file: str,
+) -> None:
+    """Execute ansible-lint and create metadata files."""
+    exclude_paths: list[str] = []
+    if not args.skip_ansible_lint:
+        serializable_result = execute_ansiblelint(
+            argv,
+            str(repository_path),
+        )
+        lint_result = str(metadata_path / "lint-result.json")
+        with Path(lint_result).open(
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write(json.dumps(serializable_result))
+
+        parse_sarif_json(exclude_paths, sarif_file)
+
+        # If syntax-errors occurred on some files, kick off the second run excluding those files
+        if len(exclude_paths) > 0 and not args.no_exclude:
+            lint_result2 = str(metadata_path / "lint-result-2.json")
+            sarif_file2 = str(metadata_path / "sarif-2.json")
+            argv = ["__DUMMY__", "--sarif-file", sarif_file2]
+            argv.append("--exclude")
+            argv.extend(exclude_paths)
+            update_argv(argv, args)
+            _logger.info(",".join(argv))
+            serializable_result_2 = execute_ansiblelint(
+                argv,
+                str(repository_path),
+            )
+            serializable_result_2["excluded"] = exclude_paths
+
+            with Path(lint_result2).open(mode="w", encoding="utf-8") as f:
+                f.write(json.dumps(serializable_result_2))
+        else:
+            lint_result2 = ""
+            sarif_file2 = ""
+
+    generate_report(
+        "" if args.skip_ansible_lint else lint_result2 if lint_result2 else lint_result,
+        sarif_file,
+        sarif_file2,
+        args,
+    )
+
+    if len(exclude_paths) > 0 and args.no_exclude:
+        msg = "One or more syntax-check errors were found by ansible-lint"
+        raise RuntimeError(msg)
+
+
+def parse_sarif_json(exclude_paths: list[str], sarif_file: str) -> None:
+    """Analyze SARIF.json to see if syntax-check errors occurred or not on the first run."""
+    with Path(sarif_file).open("rb") as f:
+        o = json.load(f)
+        for run in o["runs"]:
+            for result in run["results"]:
+                if result["ruleId"].startswith("syntax-check"):
+                    exclude_paths.extend(
+                        [
+                            location["physicalLocation"]["artifactLocation"]["uri"]
+                            for location in result["locations"]
+                        ],
+                    )
 
 
 def update_argv(argv: list[str], args: argparse.Namespace) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,6 +82,46 @@ repository: "https://www.github.com/my_org/my_collection"
 description: Sample description
 """
 
+# From a sample file in ansible-lint repo
+sample_playbook2 = """---
+- name: One
+  hosts: all
+  tasks:
+    - name: Test when with jinja2 # noqa: jinja[spacing]
+      ansible.builtin.debug:
+        msg: text
+      when: "{{ false }}"
+
+- name: Two
+  hosts: all
+  roles:
+    - role: hello
+      when: "{{ '1' = '1' }}"
+
+- name: Three
+  hosts: all
+  roles:
+    - role: hello
+      when:
+        - "{{ '1' = '1' }}"
+"""
+
+# An example with a deprecated module (ec2)
+sample_playbook3 = """---
+- name: EC2 Sample
+  hosts: all
+  tasks:
+    - ec2:
+        key_name: mykey
+        instance_type: t2.micro
+        image: ami-123456
+        wait: yes
+        group: server
+        count: 3
+        vpc_subnet_id: subnet-29e63245
+        assign_public_ip: yes
+"""
+
 dot_ansible_lint = """---
 # .ansible-lint
 profile: basic
@@ -89,6 +129,8 @@ verbosity: 1
 """
 
 sample_playbook_name = "playbook.yml"
+sample_playbook2_name = "transform-no-jinja-when.yml"
+sample_playbook3_name = "ec2-sample.yml"
 galaxy_yml_name = "galaxy.yml"
 dot_ansible_lint_name = ".ansible-lint"
 repo_name = "repo_name"
@@ -108,8 +150,8 @@ def temp_dir() -> Generator[TemporaryDirectory[str], None, None]:
 class TestMain(TestCase):
     """The TestMain class."""
 
-    def create_repo(self, source: TemporaryDirectory[str]) -> None:
-        """Create a playbook YAML file."""
+    def _create_repo(self, source: TemporaryDirectory[str]) -> None:
+        """Create a repository."""
         with (Path(source.name) / sample_playbook_name).open("w") as f:
             f.write(sample_playbook)
         with (Path(source.name) / galaxy_yml_name).open("w") as f:
@@ -117,13 +159,23 @@ class TestMain(TestCase):
         with (Path(source.name) / dot_ansible_lint_name).open("w") as f:
             f.write(dot_ansible_lint)
 
-    def create_tarball(
+    def _add_second_playbook(self, source: TemporaryDirectory[str]) -> None:
+        """Add the second playbook YAML file."""
+        with (Path(source.name) / sample_playbook2_name).open("w") as f:
+            f.write(sample_playbook2)
+
+    def _add_third_playbook(self, source: TemporaryDirectory[str]) -> None:
+        """Add the second playbook YAML file."""
+        with (Path(source.name) / sample_playbook3_name).open("w") as f:
+            f.write(sample_playbook3)
+
+    def _create_tarball(
         self,
         source: TemporaryDirectory[str],
         compression: str = "",
     ) -> None:
         """Create a tarball."""
-        self.create_repo(source)
+        self._create_repo(source)
         os.chdir(source.name)
         filename = (
             f"{repo_name}.tar.{compression}" if compression else f"{repo_name}.tar"
@@ -134,9 +186,9 @@ class TestMain(TestCase):
             tar.add(galaxy_yml_name)
             tar.add(dot_ansible_lint_name)
 
-    def create_zip_file(self, source: TemporaryDirectory[str]) -> None:
+    def _create_zip_file(self, source: TemporaryDirectory[str]) -> None:
         """Create a ZIP file."""
-        self.create_repo(source)
+        self._create_repo(source)
         os.chdir(source.name)
         with zipfile.ZipFile(
             f"{repo_name}.zip",
@@ -150,7 +202,9 @@ class TestMain(TestCase):
     def test_cli_with_local_directory(self) -> None:
         """Run the CLI with a local directory."""
         with temp_dir() as source:
-            self.create_repo(source)
+            self._create_repo(source)
+            self._add_second_playbook(source)
+            self._add_third_playbook(source)
             with temp_dir() as output:
                 testargs = [
                     "ansible-content-parser",
@@ -185,10 +239,31 @@ class TestMain(TestCase):
                             line = f.readline()
                             assert line == "---------------------\n"
 
+    def test_cli_with_local_directory_with_no_exclude(self) -> None:
+        """Run the CLI with a local directory."""
+        with temp_dir() as source:
+            self._create_repo(source)
+            self._add_second_playbook(source)
+            self._add_third_playbook(source)
+            with temp_dir() as output:
+                testargs = [
+                    "ansible-content-parser",
+                    "-v",
+                    "--no-exclude",
+                    source.name + "/",  # intentionally add "/" to the end
+                    output.name,
+                ]
+                with patch.object(sys, "argv", testargs), self.assertRaises(
+                    SystemExit,
+                ) as context:
+                    main()
+
+                    assert context.exception.code == 1, "The exit code should be 1"
+
     def test_cli_with_non_archive_file(self) -> None:
         """Run the CLI with specifying a non archive file as input."""
         with temp_dir() as source:
-            self.create_repo(source)
+            self._create_repo(source)
             with temp_dir() as output:
                 testargs = [
                     "ansible-content-parser",
@@ -242,7 +317,7 @@ class TestMain(TestCase):
     def test_cli_with_tarball(self) -> None:
         """Run the CLI with a tarball."""
         with temp_dir() as source:
-            self.create_tarball(source)
+            self._create_tarball(source)
             with temp_dir() as output:
                 testargs = [
                     "ansible-content-parser",
@@ -260,7 +335,7 @@ class TestMain(TestCase):
     def test_cli_with_compressed_tarball(self) -> None:
         """Run the CLI with a tarball (.tar.gz)."""
         with temp_dir() as source:
-            self.create_tarball(source, "gz")
+            self._create_tarball(source, "gz")
             with temp_dir() as output:
                 testargs = [
                     "ansible-content-parser",
@@ -294,7 +369,7 @@ class TestMain(TestCase):
     def test_cli_with_invalid_tarball(self) -> None:
         """Run the CLI with an invalid tarball."""
         with temp_dir() as source:
-            self.create_zip_file(source)
+            self._create_zip_file(source)
             (Path(source.name) / f"{repo_name}.zip").rename(
                 str(Path(source.name) / f"{repo_name}.tar"),
             )
@@ -327,7 +402,7 @@ class TestMain(TestCase):
     def test_cli_with_zip_file(self) -> None:
         """Run the CLI with a zip file."""
         with temp_dir() as source:
-            self.create_zip_file(source)
+            self._create_zip_file(source)
             with temp_dir() as output:
                 testargs = [
                     "ansible-content-parser",
@@ -343,7 +418,7 @@ class TestMain(TestCase):
     def test_cli_with_invalid_zip_file(self) -> None:
         """Run the CLI with an invalid zip file."""
         with temp_dir() as source:
-            self.create_tarball(source, "gz")
+            self._create_tarball(source, "gz")
             (Path(source.name) / f"{repo_name}.tar.gz").rename(
                 str(Path(source.name) / f"{repo_name}.zip"),
             )


### PR DESCRIPTION
For [AAP-16136](https://issues.redhat.com/browse/AAP-16136).

Note: This is built on the top of #11.