### PR TITLE
Replace --skip-transform option with --fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ with a few optional parameters.
 ```commandline
 $ ansible-content-parser --help
 usage: ansible-content-parser [-h] [--config-file CONFIG_FILE]
-                              [--profile {min,basic,moderate,safety,shared,production}] [--skip-transform]
+                              [--profile {min,basic,moderate,safety,shared,production}] [--fix WRITE_LIST]
                               [--skip-ansible-lint] [--no-exclude] [-v] [--source-license SOURCE_LICENSE]
                               [--source-description SOURCE_DESCRIPTION] [--repo-name REPO_NAME] [--repo-url REPO_URL]
                               [--version]
@@ -50,8 +50,9 @@ options:
                         lint', '.config/ansible-lint.yml', or '.config/ansible-lint.yaml' in the source repository.
   --profile {min,basic,moderate,safety,shared,production}
                         Specify which rules profile to be used for ansible-lint
-  --skip-transform      Skip the transform step of ansible-lint. If this option is not specified, ansible-lint is
-                        executed with the --fix option and files are transformed according to the rules specified.
+  --fix WRITE_LIST      Specify how ansible-lint performs auto-fixes, including YAML reformatting. You can limit the
+                        effective rule transforms (the 'write_list') by passing a keywords 'all' (=default) or 'none'
+                        or a comma separated list of rule ids or rule tags.
   --skip-ansible-lint   Skip the execution of ansible-lint.
   --no-exclude          Do not rerun ansible-lint with excluding files that caused syntax check errors. If one or more
                         syntax check errors were found, execution fails without generating the training dataset.

--- a/src/ansible_content_parser/__main__.py
+++ b/src/ansible_content_parser/__main__.py
@@ -81,10 +81,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Specify which rules profile to be used for ansible-lint",
     )
     parser.add_argument(
-        "--skip-transform",
-        action="store_true",
-        help="Skip the transform step of ansible-lint.  If this option is not specified, ansible-lint is executed "
-        "with the --fix option and files are transformed according to the rules specified.",
+        "--fix",
+        dest="write_list",  # This is how this option is stored in ansible_lint.
+        # default="all", <-- Commented out because this does not work as expected.
+        help="Specify how ansible-lint performs auto-fixes, including YAML reformatting. "
+        "You can limit the effective rule transforms (the 'write_list') by passing a "
+        "keywords 'all' (=default) or 'none' or a comma separated list of rule ids or "
+        "rule tags.",
     )
     parser.add_argument(
         "--skip-ansible-lint",
@@ -396,8 +399,10 @@ def parse_sarif_json(exclude_paths: list[str], sarif_file: str) -> None:
 
 def update_argv(argv: list[str], args: argparse.Namespace) -> None:
     """Update arguments to ansible-lint based on arguments given to ansible-content-parser."""
-    if not args.skip_transform:
+    if getattr(args, "write_list", None) is None:
         argv.append("--fix=all")
+    else:
+        argv.append(f"--fix={args.write_list}")
     if args.verbose:
         argv.append("-v")
     if args.config_file:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -503,7 +503,7 @@ class TestMain(TestCase):
     def test_update_argv(self) -> None:
         """Test __main__.update_argv()."""
         input_data = {
-            "skip_transform": True,
+            "write_list": "none",
             "verbose": True,
             "config_file": "config.file",
             "profile": "basic",
@@ -512,7 +512,7 @@ class TestMain(TestCase):
         argv = ["__DUMMY__"]
         update_argv(argv, args)
 
-        assert "--fix=all" not in argv
+        assert "--fix=none" in argv
         assert "-v" in argv
         assert "--config-file" in argv
         assert "config.file" in argv
@@ -520,7 +520,6 @@ class TestMain(TestCase):
         assert "basic" in argv
 
         input_data = {
-            "skip_transform": False,
             "verbose": False,
             "config_file": None,
             "profile": None,
@@ -533,6 +532,21 @@ class TestMain(TestCase):
         assert "-v" not in argv
         assert "--config-file" not in argv
         assert "--profile" not in argv
+
+        input_data = {
+            "write_list": "command-instead-of-shell,deprecated-local-action,no-log-password",
+            "verbose": False,
+            "config_file": None,
+            "profile": None,
+        }
+        args = argparse.Namespace(**input_data)
+        argv = ["__DUMMY__"]
+        update_argv(argv, args)
+
+        assert (
+            "--fix=command-instead-of-shell,deprecated-local-action,no-log-password"
+            in argv
+        )
 
     def test_get_project_root(self) -> None:
         with temp_dir() as output:


### PR DESCRIPTION
For [AAP-16412](https://issues.redhat.com/browse/AAP-16412).

This will replace the `--skip-transform` option with the `--fix` option. While the `--skip-transform` option was for turning on/off the transform feature of `ansible-lint`, the new `--fix` option provides more flexibility (including turning on/off) by just passing the specified parameters to `ansible-lint`.