### PR TITLE
Change the behavior of --no-exclude option

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,4 +1,6 @@
 ansiblelint
+autofix
+autofixed
 clamav
 clamscan
 commandline

--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 ## Overview
 
-`ansible-content-parser` used for analyze Ansible files, such
-as playbooks, task files, etc. in a given directory.
-
-It runs `ansible-lint` internally against a given
-source directory and
-updates Ansible files (the `--fix` option of `ansible-lint`)
-and generates the `lint-result.json` file, which summarizes
-files found in the directory and lint errors.
+`ansible-content-parser` analyzes Ansible files in a given source
+(a local directory, an archive file or a git URL)
+by running `ansible-lint` internally,
+updates Ansible files using the [Autofix feature of `ansible-lint`](https://ansible.readthedocs.io/projects/lint/autofix/)
+and generates the `ftdata.json` file, which is the training dataset
+for developing custom AI models used with Ansible Lightspeed.
 
 ## Build
 
@@ -54,8 +52,9 @@ options:
                         effective rule transforms (the 'write_list') by passing a keywords 'all' (=default) or 'none'
                         or a comma separated list of rule ids or rule tags.
   --skip-ansible-lint   Skip the execution of ansible-lint.
-  --no-exclude          Do not rerun ansible-lint with excluding files that caused syntax check errors. If one or more
-                        syntax check errors were found, execution fails without generating the training dataset.
+  --no-exclude          Do not let ansible-content-parser to generate training dataset by excluding files that caused
+                        lint errors. With this option specified, a single lint error terminates the execution without
+                        generating the training dataset.
   -v, --verbose         Explain what is being done
   --source-license SOURCE_LICENSE
                         Specify the license that will be included in the training dataset.

--- a/src/ansible_content_parser/__main__.py
+++ b/src/ansible_content_parser/__main__.py
@@ -292,7 +292,7 @@ def main() -> None:
         metadata_path = out_path / "metadata"
 
         sarif_file = str(metadata_path / "sarif.json")
-        argv = ["__DUMMY__", "--sarif-file", sarif_file]
+        argv = ["ansible-lint", "--sarif-file", sarif_file]
         update_argv(argv, args)
 
         try:
@@ -337,7 +337,15 @@ def execute_lint_step(
 ) -> None:
     """Execute ansible-lint and create metadata files."""
     exclude_paths: list[str] = []
-    if not args.skip_ansible_lint:
+
+    lint_result = ""
+    lint_result2 = ""
+    sarif_file2 = ""
+    return_code = RC.SUCCESS
+
+    if args.skip_ansible_lint:
+        sarif_file = ""
+    else:
         serializable_result, return_code = execute_ansiblelint(
             argv,
             str(repository_path),
@@ -356,7 +364,7 @@ def execute_lint_step(
             if len(exclude_paths) > 0:
                 lint_result2 = str(metadata_path / "lint-result-2.json")
                 sarif_file2 = str(metadata_path / "sarif-2.json")
-                argv = ["__DUMMY__", "--sarif-file", sarif_file2]
+                argv = ["ansible-lint", "--sarif-file", sarif_file2]
                 argv.append("--exclude")
                 argv.extend(exclude_paths)
                 update_argv(argv, args)
@@ -374,8 +382,6 @@ def execute_lint_step(
                     f.write(json.dumps(serializable_result_2))
             else:
                 exclude_paths = parse_sarif_json(exclude_paths, sarif_file, False)
-                lint_result2 = ""
-                sarif_file2 = ""
 
     generate_report(
         lint_result,

--- a/src/ansible_content_parser/lint.py
+++ b/src/ansible_content_parser/lint.py
@@ -98,6 +98,6 @@ def ansiblelint_main(argv: list[str] | None = None) -> LintResult:
             ",".join(options.mock_filters),
         )
 
-    app.report_outcome(result, mark_as_success=mark_as_success)
+    return_code = app.report_outcome(result, mark_as_success=mark_as_success)
 
-    return result, mark_as_success
+    return result, mark_as_success, return_code

--- a/src/ansible_content_parser/report.py
+++ b/src/ansible_content_parser/report.py
@@ -20,7 +20,7 @@ _logger = logging.getLogger(__name__)
 _label_count = "Count"
 _label_file_type = "File Type"
 _label_file_path = "File Path"
-_label_file_state = "Updated"
+_label_file_state = "Excluded/Autofixed"
 _label_module_name = "Module Name"
 _label_total = "TOTAL"
 
@@ -89,7 +89,7 @@ def get_file_list_summary(files: list[LintableDict], excluded_paths: list[str]) 
             state = (
                 "excluded"
                 if excluded[filename]
-                else "updated"
+                else "autofixed"
                 if updated[filename]
                 else ""
             )
@@ -281,7 +281,8 @@ Output Directory      : {args.output}
 {get_sarif_summary(metadata_path, sarif_file2)}
 """
     else:
-        report += f"""
+        if sarif_file:
+            report += f"""
 {get_sarif_summary(metadata_path, sarif_file)}
 """
     with (out_path / _report_txt).open(mode="w") as f:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -210,6 +210,8 @@ class TestMain(TestCase):
                 testargs = [
                     "ansible-content-parser",
                     "-v",
+                    "--profile",
+                    "min",
                     source.name + "/",  # intentionally add "/" to the end
                     output.name,
                 ]


### PR DESCRIPTION
For changing the behavior of --no-exclude option.

On the current version, it is implemented as:

```
  --no-exclude          Do not rerun ansible-lint with excluding files that
                        caused syntax check errors. If one or more syntax check
                        errors were found, execution fails without generating
                        the training dataset.
```
We will change this behavior (with keeping the name of the option) to

```
  --no-exclude          Do not let ansible-content-parser to generate 
                        training dataset by excluding files that caused lint errors. 
                        With this option specified, a single lint error terminates  
                        the execution without generating the training dataset.
```
i.e., we will treat syntax check errors and other lint errors in the same way after the change.