### PR TITLE
Upgrade ansible-lint to 6.20.1

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,6 +1,6 @@
 # Special order section for helping pip:
 will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
-ansible-lint>=6.20.0
+ansible-lint>=6.20.1
 GitPython
 giturlparse
 sarif-tools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
         additional_dependencies:
           - pytest
           - tox
-          - ansible-lint
+          - ansible-lint>=6.20.1
           - GitPython
 
   - repo: https://github.com/pre-commit/mirrors-mypy.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 ansible==8.4.0
 ansible-compat==4.1.10
 ansible-core==2.15.4
-ansible-lint==6.20.0
+ansible-lint==6.20.1
 ansible-risk-insight==0.2.0
 attrs==23.1.0
 black==23.7.0

--- a/src/ansible_content_parser/lint.py
+++ b/src/ansible_content_parser/lint.py
@@ -49,7 +49,7 @@ def ansiblelint_main(argv: list[str] | None = None) -> LintResult:
 
     # pylint: disable=import-outside-toplevel
     from ansiblelint.rules import RulesCollection
-    from ansiblelint.runner import _get_matches
+    from ansiblelint.runner import get_matches
 
     app = get_app(offline=None)  # to be sure we use the offline value from settings
     rules = RulesCollection(
@@ -61,7 +61,7 @@ def ansiblelint_main(argv: list[str] | None = None) -> LintResult:
 
     if isinstance(options.tags, str):
         options.tags = options.tags.split(",")  # pragma: no cover
-    result = _get_matches(rules, options)
+    result = get_matches(rules, options)
 
     if options.write_list:
         ruamel_safe_version = "0.17.26"


### PR DESCRIPTION
For [AAP-16653](https://issues.redhat.com/browse/AAP-16653).

Since [this change in this version of ansible-lint](https://github.com/ansible/ansible-lint/pull/3774) changed a name of a method that was used in Content Parser (well, we should not have used it because the method name started with `_`...), we need to make a small change in our code.