### PR TITLE
Update ansible-lint to 6.20.2 and fix a report issue on excluded files

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,6 +1,6 @@
 # Special order section for helping pip:
 will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
-ansible-lint>=6.20.1
+ansible-lint>=6.20.2
 GitPython
 giturlparse
 sarif-tools

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+omit = tests/*
+
+[report]
+skip_covered = True
+skip_empty = True
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
         additional_dependencies:
           - pytest
           - tox
-          - ansible-lint>=6.20.1
+          - ansible-lint>=6.20.2
           - GitPython
 
   - repo: https://github.com/pre-commit/mirrors-mypy.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 ansible==8.4.0
 ansible-compat==4.1.10
 ansible-core==2.15.4
-ansible-lint==6.20.1
+ansible-lint==6.20.2
 ansible-risk-insight==0.2.0
 attrs==23.1.0
 black==23.7.0

--- a/src/ansible_content_parser/__main__.py
+++ b/src/ansible_content_parser/__main__.py
@@ -5,6 +5,7 @@ via :command:`python -m ansible_content_parser`.
 """
 import argparse
 import contextlib
+import copy  # pylint: disable=preferred-module
 import errno
 import json
 import logging
@@ -373,7 +374,9 @@ def execute_lint_step(
                     argv,
                     str(repository_path),
                 )
-                serializable_result_2["excluded"] = exclude_paths
+                # create a shallow copy of exclude_paths because the following parse_sarif_json() call
+                # will add more files to the list.
+                serializable_result_2["excluded"] = copy.copy(exclude_paths)
                 exclude_paths = parse_sarif_json(exclude_paths, sarif_file2, False)
 
                 _rename_excluded_files(exclude_paths, repository_path)


### PR DESCRIPTION
For [AAP-16692](https://issues.redhat.com/browse/AAP-16692).

This PR contains three changes:

- Upgrade ansible-lint from 6.20.1 to 6.20.2
- Added the `.coveragerc` file not to include test case files in the code coverage calculation
- Fix an issue in reporting (report.txt) on the list of excluded files, in the "Issues found by ansible-lint" section. While it should include the files excluded from the second ansible-lint execution, it included the files that contained lint errors in the second execution as well.