### PR TITLE
Add module property to training dataset (ftdata.json)

### DIFF
--- a/src/ansible_content_parser/gen_ftdata.py
+++ b/src/ansible_content_parser/gen_ftdata.py
@@ -21,6 +21,7 @@ class _FTRecord(TypedDict):
     data_source_description: str
     input: str
     license: str
+    module: str
     output: str
     path: str
     repo_name: str
@@ -36,6 +37,7 @@ def _gen_ftdata(task: Task, parent: SageObject) -> _FTRecord:
         data_source_description="",
         input="",
         license="",
+        module="",
         output="",
         path="",
         repo_name="",
@@ -44,6 +46,7 @@ def _gen_ftdata(task: Task, parent: SageObject) -> _FTRecord:
 
     record["data_source_description"] = task.source.get("data_source_description", "")
     record["license"] = task.source.get("license", "")
+    record["module"] = task.module
     record["repo_url"] = task.source.get("repo_url", "")
     record["repo_name"] = task.source.get("repo_name", "")
     record["path"] = task.filepath

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -417,6 +417,7 @@ class TestMain(TestCase):
                         assert o["repo_name"] == "test_repo"
                         assert o["repo_url"] == "https://repo.example.com/test_repo"
                         assert o["license"] == "Apache"
+                        assert o["module"] != ""
 
     def test_cli_with_invalid_tarball(self) -> None:
         """Run the CLI with an invalid tarball."""


### PR DESCRIPTION
Add module property to training dataset (ftdata.json).

If the fqcn rule is enabled on the ansible-lint step, the property will contain fqcn names. Otherwise, it will contain  module names found in the source.