### PR TITLE
Files with lint violations are not properly excluded

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,6 +1,6 @@
 # Special order section for helping pip:
 will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
-ansible-lint>=6.20.2
+ansible-lint>=6.20.3
 GitPython
 giturlparse
 sarif-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 ansible==8.4.0
 ansible-compat==4.1.10
 ansible-core==2.15.4
-ansible-lint==6.20.2
+ansible-lint==6.20.3
 ansible-risk-insight==0.2.0
 attrs==23.1.0
 black==23.7.0

--- a/src/ansible_content_parser/__main__.py
+++ b/src/ansible_content_parser/__main__.py
@@ -379,12 +379,19 @@ def execute_lint_step(
                 serializable_result_2["excluded"] = copy.copy(exclude_paths)
                 exclude_paths = parse_sarif_json(exclude_paths, sarif_file2, False)
 
-                _rename_excluded_files(exclude_paths, repository_path)
-
                 with Path(lint_result2).open(mode="w", encoding="utf-8") as f:
                     f.write(json.dumps(serializable_result_2))
             else:
                 exclude_paths = parse_sarif_json(exclude_paths, sarif_file, False)
+
+            if len(exclude_paths) > 0:
+                # Rename excluded files to have __EXCLUDED__ extension so that they won't be processed by sage
+                _rename_excluded_files(exclude_paths, repository_path)
+                _logger.warning(
+                    "Following files are excluded from training set generation due to ansible-lint rule "
+                    "violations: %s",
+                    ",".join(exclude_paths),
+                )
 
     generate_report(
         lint_result,

--- a/src/ansible_content_parser/gen_ftdata.py
+++ b/src/ansible_content_parser/gen_ftdata.py
@@ -115,5 +115,8 @@ def gen_ftdata_json(sage_objects_json: str, ftdata_json: str) -> None:
                         task.yaml_lines,
                     )
 
-    with Path(ftdata_json).open("w", encoding="utf-8") as file:
-        file.write("".join(record_lines))
+    if len(record_lines) == 0:
+        _logger.warning("No training data set was created.")
+    else:
+        with Path(ftdata_json).open("w", encoding="utf-8") as file:
+            file.write("".join(record_lines))


### PR DESCRIPTION
Ansible files with lint violations were supposed to be excluded from the following Sage pipeline, but they were not excluded unless there were syntax check errors at the first execution of ansible-lint.

With fixing the issue, I have added following changes:

- Added a warning message when there were files excluded from Sage pipeline:
```
            if len(exclude_paths) > 0:
                # Rename excluded files to have __EXCLUDED__ extension so that they won't be processed by sage
                _rename_excluded_files(exclude_paths, repository_path)
                _logger.warning(
                    "Following files are excluded from training set generation due to ansible-lint rule "
                    "violations: %s",
                    ",".join(exclude_paths),
                )

```
- Added a warning message when there was no training dataset found in the source
```
    if len(record_lines) == 0:
        _logger.warning("No training data set was created.")
```

- Upgrade ansible-lint to 6.20.3