### PR TITLE
upgrade urllib3 to 2.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,6 @@ smmap==5.0.0
 subprocess-tee==0.4.1
 tabulate==0.9.0
 treelib==1.7.0
-urllib3==2.0.4
+urllib3==2.0.7
 wcmatch==8.5
 yamllint==1.32.0


### PR DESCRIPTION
<!--- Put corresponding issue link below. -->
Issue: https://issues.redhat.com/browse/AAP-18215

## Description
Upgrade urllib3 to 2.0.7 for vulnerability

## Testing
### Steps to test
1. Pull down the PR
2. Run `tox` to build local ansible-content-parser
3. Run `pip install dist/ansible_content_parser-0.0.7.dev4-py3-none-any.whl` to install new build
4. Run `ansible-content-parser git@github.com:ansible/workshop-examples.git /tmp/parser-out` and confirm ansible-content-parser runs successfully 

### Scenarios tested
Steps above.
