### PR TITLE
upgrade gitpython to 3.1.37

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ cycler==0.11.0
 filelock==3.12.4
 fonttools==4.42.1
 gitdb==4.0.10
-gitpython==3.1.36
+gitpython==3.1.37
 giturlparse==0.11.1
 idna==3.4
 jinja2==3.1.2


### PR DESCRIPTION
<!--- Put corresponding issue link below. -->
Issue: https://issues.redhat.com/browse/AAP-17832

## Description
Upgrade gitpython to 3.1.37 for vulnerability

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run tox to build local ansible-content-parser
3. Run pip install dist/ansible_content_parser-0.0.7.dev4-py3-none-any.whl to install new build
4. Run ansible-content-parser git@github.com:ansible/workshop-examples.git /tmp/parser-out and confirm ansible-content-parser runs successfully

### Scenarios tested
Steps above.
