### PR TITLE
Add the shorter option (-S) for --skip-ansible-lint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,21 @@
 <!--- Put corresponding issue link below. -->
-Issue: 
+
+Issue:
 
 ## Description
+
 <!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions. -->
 
 ## Testing
+
 <!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
+
 ### Steps to test
+
 1. Pull down the PR
 2. ...
 3. ...
 
 ### Scenarios tested
+
 <!-- Describe the scenarios you've already manually verified, if applicable. -->

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ options:
   --fix WRITE_LIST      Specify how ansible-lint performs auto-fixes, including YAML reformatting. You can limit the
                         effective rule transforms (the 'write_list') by passing a keywords 'all' (=default) or 'none'
                         or a comma separated list of rule ids or rule tags.
-  --skip-ansible-lint   Skip the execution of ansible-lint.
+  -S, --skip-ansible-lint
+                        Skip the execution of ansible-lint.
   --no-exclude          Do not let ansible-content-parser to generate training dataset by excluding files that caused
                         lint errors. With this option specified, a single lint error terminates the execution without
                         generating the training dataset.

--- a/src/ansible_content_parser/__main__.py
+++ b/src/ansible_content_parser/__main__.py
@@ -91,6 +91,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "rule tags.",
     )
     parser.add_argument(
+        "-S",
         "--skip-ansible-lint",
         action="store_true",
         help="Skip the execution of ansible-lint.",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -284,7 +284,9 @@ class TestMain(TestCase):
                             line = f.readline()
                             assert line == "---------------------\n"
 
-    def sub_test_cli_with_local_directory_with_no_ansible_lint(self, option: str) -> None:
+    def sub_test_cli_with_local_directory_with_no_ansible_lint(
+        self, option: str,
+    ) -> None:
         """Run the CLI with a local directory."""
         with temp_dir() as source:
             self._create_repo(source)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -285,7 +285,8 @@ class TestMain(TestCase):
                             assert line == "---------------------\n"
 
     def sub_test_cli_with_local_directory_with_no_ansible_lint(
-        self, option: str,
+        self,
+        option: str,
     ) -> None:
         """Run the CLI with a local directory."""
         with temp_dir() as source:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -284,7 +284,7 @@ class TestMain(TestCase):
                             line = f.readline()
                             assert line == "---------------------\n"
 
-    def sub_test_cli_with_local_directory_with_no_ansible_lint(self, option) -> None:
+    def sub_test_cli_with_local_directory_with_no_ansible_lint(self, option: str) -> None:
         """Run the CLI with a local directory."""
         with temp_dir() as source:
             self._create_repo(source)
@@ -329,13 +329,19 @@ class TestMain(TestCase):
                             line = f.readline()
                             assert line == "---------------------\n"
 
-    def test_cli_with_local_directory_with_no_ansible_lint_with_long_option(self) -> None:
-        """Run the CLI with a local directory with the --skip-ansible-lint option"""
-        self.sub_test_cli_with_local_directory_with_no_ansible_lint('--skip-ansible-lint')
+    def test_cli_with_local_directory_with_no_ansible_lint_with_long_option(
+        self,
+    ) -> None:
+        """Run the CLI with a local directory with the --skip-ansible-lint option."""
+        self.sub_test_cli_with_local_directory_with_no_ansible_lint(
+            "--skip-ansible-lint",
+        )
 
-    def test_cli_with_local_directory_with_no_ansible_lint_with_short_option(self) -> None:
-        """Run the CLI with a local directory with the -S option"""
-        self.sub_test_cli_with_local_directory_with_no_ansible_lint('-S')
+    def test_cli_with_local_directory_with_no_ansible_lint_with_short_option(
+        self,
+    ) -> None:
+        """Run the CLI with a local directory with the -S option."""
+        self.sub_test_cli_with_local_directory_with_no_ansible_lint("-S")
 
     def test_cli_with_local_directory_with_no_exclude(self) -> None:
         """Run the CLI with a local directory."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -284,7 +284,7 @@ class TestMain(TestCase):
                             line = f.readline()
                             assert line == "---------------------\n"
 
-    def test_cli_with_local_directory_with_no_ansible_lint(self) -> None:
+    def sub_test_cli_with_local_directory_with_no_ansible_lint(self, option) -> None:
         """Run the CLI with a local directory."""
         with temp_dir() as source:
             self._create_repo(source)
@@ -294,7 +294,7 @@ class TestMain(TestCase):
                 testargs = [
                     "ansible-content-parser",
                     "-v",
-                    "--skip-ansible-lint",
+                    option,
                     source.name,
                     output.name,
                 ]
@@ -328,6 +328,14 @@ class TestMain(TestCase):
                             assert line == "TOTAL               6\n"
                             line = f.readline()
                             assert line == "---------------------\n"
+
+    def test_cli_with_local_directory_with_no_ansible_lint_with_long_option(self) -> None:
+        """Run the CLI with a local directory with the --skip-ansible-lint option"""
+        self.sub_test_cli_with_local_directory_with_no_ansible_lint('--skip-ansible-lint')
+
+    def test_cli_with_local_directory_with_no_ansible_lint_with_short_option(self) -> None:
+        """Run the CLI with a local directory with the -S option"""
+        self.sub_test_cli_with_local_directory_with_no_ansible_lint('-S')
 
     def test_cli_with_local_directory_with_no_exclude(self) -> None:
         """Run the CLI with a local directory."""


### PR DESCRIPTION
<!--- Put corresponding issue link below. -->
Issue:  No JIRA issue opened for this.

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions. -->
Provide the shorter alternative option (`-S`) for the `--skip-ansible-lint` option for better usability.  `-s` (lowercase) was not chosen because it is used as the `--strict` option in `ansible-lint`.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
Run `ansible-content-parser` with `-S` option and  verify the `report.txt` file in the output directory does not contain outputs from `ansible-lint`. A Unit test is also included in this PR.

### Steps to test

#### Build & install the updated code

1. Change to a work directory like `/var/tmp`
2. Download the PR branch:
```
git clone git@github.com:ansible/ansible-content-parser.git
cd ansible-content-parser/
git checkout 'ttakamiy/skip-ansible-lint-short-option'
```
3. Make sure python3 > 3.10 and create & activate venv
```
python3 -V
python3 -m venv venv
source venv/bin/activate
```
4. Upgrade `pip` and install dependencies
```
pip install --upgrade pip
pip install -e '.[test]'
```
5. Reactivate venv
```
deactivate
source venv/bin/activate
```
6. Run `tox` to build installable images  (it also runs unit tests)
```
tox
```
7. Install the .whl file built by `tox`
```
pip install dist/ansible_content_parser-xxxxxxx-py3-none-any.whl
```
8. Reactivate venv
```
deactivate
source venv/bin/activate
```
9. Run `ansible-content-parser` with the `--help` option and verify the new `-S` option shows up
```
ansible-content-parser --help
```
10. Run `ansible-content-parser` with the `-S `option against a simple sample project
```
ansible-content-parser -S https://github.com/ansible/ansible-tower-samples out
```
11. Check `out/report.txt` to verify there is no outputs from `ansible-lint`
```
cat out/report.txt
```

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
See the "Steps to test" section.
