### PR TITLE
Upgrade ansible-lint to 6.22.1

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,6 +1,6 @@
 # Special order section for helping pip:
 will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
-ansible-lint>=6.20.3
+ansible-lint>=6.22.1
 GitPython
 giturlparse
 sarif-tools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
         additional_dependencies:
           - pytest
           - tox
-          - ansible-lint>=6.20.2
+          - ansible-lint>=6.22.1
           - GitPython
 
   - repo: https://github.com/pre-commit/mirrors-mypy.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 ansible==8.4.0
 ansible-compat==4.1.10
 ansible-core==2.15.4
-ansible-lint==6.20.3
+ansible-lint==6.22.1
 ansible-risk-insight==0.2.4
 attrs==23.1.0
 black==23.7.0
@@ -56,7 +56,7 @@ requests==2.31.0
 resolvelib==1.0.1
 rich==13.5.2
 rpds-py==0.10.3
-ruamel-yaml==0.17.32
+ruamel-yaml==0.18.5
 ruamel-yaml-clib==0.2.7
 sage-scan==0.0.3
 sarif-tools==1.0.0


### PR DESCRIPTION
<!--- Put corresponding issue link below. -->

Issue: [AAP-17059](https://issues.redhat.com/browse/AAP-17059) Publish ansible-content-parser with 1.x version

## Description

<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions. -->

Upgrade ansible-lint to its latest version 6.22.1.

## Testing

<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
- Verify the `--version` option displays the latest ansible-lint version
- Run regular operations to make sure if no functions are broken with the latest

### Steps to test

1. Build the Content Parser following [the instructions](https://github.com/ansible/ansible-content-parser/wiki/Build)
2. Execute `ansible-content-parser --version` to verify the version of ansible-lint installed.
3. Run `ansible-content-parser` against Ansible code repositories to make sure if no function are broken.

### Scenarios tested
Verified the `--version` displayed ansible-lint version 6.22.1 and `ansible-content-parser` could generate
`ftdata.json` file from [the ansible-examples repo](https://github.com/ansible/ansible-examples.git).
<!-- Describe the scenarios you've already manually verified, if applicable. -->

