### PR TITLE
Change output file extension from .json to .jsonl and specify ANSIBLE_LINT_NODEPS envvar

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -19,6 +19,7 @@ inodes
 lightspeed
 lintable
 mockings
+nodeps
 nodocs
 nosonar
 pythonpath

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 (a local directory, an archive file or a git URL)
 by running `ansible-lint` internally,
 updates Ansible files using the [Autofix feature of `ansible-lint`](https://ansible.readthedocs.io/projects/lint/autofix/)
-and generates the `ftdata.json` file, which is the training dataset for
+and generates the `ftdata.jsonl` file, which is the training dataset for
 developing custom AI models.
 
 ## Build
@@ -174,7 +174,7 @@ positional argument.
 
 ```
 output/
-  |-- ftdata.json  # Training dataset
+  |-- ftdata.jsonl # Training dataset
   |-- report.txt   # A human-readable report
   |
   |-- repository/
@@ -186,7 +186,7 @@ output/
         |-- (other metadata files generated)
 ```
 
-### ftdata.json
+### ftdata.jsonl
 
 This is the training dataset file, which is the main output of `ansible-content-parser`.
 

--- a/src/ansible_content_parser/gen_ftdata.py
+++ b/src/ansible_content_parser/gen_ftdata.py
@@ -92,8 +92,8 @@ def _gen_ftdata(task: Task, parent: SageObject) -> _FTRecord:
     return record
 
 
-def gen_ftdata_json(sage_objects_json: str, ftdata_json: str) -> None:
-    """Generate ftdata.json file."""
+def gen_ftdata_jsonl(sage_objects_json: str, ftdata_jsonl: str) -> None:
+    """Generate ftdata.jsonl file."""
     record_lines = []
     for project in load_objects(sage_objects_json).projects():
         parents = []
@@ -118,5 +118,5 @@ def gen_ftdata_json(sage_objects_json: str, ftdata_json: str) -> None:
     if len(record_lines) == 0:
         _logger.warning("No training data set was created.")
     else:
-        with Path(ftdata_json).open("w", encoding="utf-8") as file:
+        with Path(ftdata_jsonl).open("w", encoding="utf-8") as file:
             file.write("".join(record_lines))

--- a/src/ansible_content_parser/lint.py
+++ b/src/ansible_content_parser/lint.py
@@ -1,12 +1,18 @@
 """Invoke ansible-lint."""
 from __future__ import annotations
 
+import os
 import sys
 
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ansiblelint.__main__ import (
+
+# Set the ANSIBLE_LINT_NODEPS envvar to "1" in order to avoid performing checks that would fail
+# when modules are not installed. Far less ansible-lint violations will be reported.
+os.environ["ANSIBLE_LINT_NODEPS"] = "1"
+
+from ansiblelint.__main__ import (  # noqa: E402
     _do_transform,
     _logger,
     _perform_mockings_cleanup,
@@ -18,7 +24,7 @@ from ansiblelint.__main__ import (
     options,
     path_inject,
 )
-from ansiblelint.color import (
+from ansiblelint.color import (  # noqa: E402
     console_options,
     reconfigure,
 )

--- a/src/ansible_content_parser/pipeline.py
+++ b/src/ansible_content_parser/pipeline.py
@@ -6,7 +6,7 @@ import os
 
 from pathlib import Path
 
-from .gen_ftdata import gen_ftdata_json
+from .gen_ftdata import gen_ftdata_jsonl
 from .report import add_module_summary
 
 
@@ -19,7 +19,7 @@ def run_pipeline(args: argparse.Namespace, repository_path: Path) -> int:
     metadata_path = out_path / "metadata"
 
     report_path = out_path / "report.txt"
-    ftdata_path = out_path / "ftdata.json"
+    ftdata_path = out_path / "ftdata.jsonl"
     lint_result_path = metadata_path / "lint-result.json"
     sage_objects_path = metadata_path / "sage-objects.json"
 
@@ -50,7 +50,7 @@ def run_pipeline(args: argparse.Namespace, repository_path: Path) -> int:
     )
 
     # Generate FT Data
-    gen_ftdata_json(
+    gen_ftdata_jsonl(
         str(sage_objects_path),
         str(ftdata_path),
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -466,7 +466,7 @@ class TestMain(TestCase):
 
                     assert context.exception.code == 0, "The exit code should be 0"
 
-                with (Path(output.name) / "ftdata.json").open("r") as f:
+                with (Path(output.name) / "ftdata.jsonl").open("r") as f:
                     for line in f:
                         o = json.loads(line)
                         assert o["data_source_description"] == "This is a repo for test"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -221,6 +221,7 @@ class TestMain(TestCase):
                     main()
 
                 assert context.exception.code == 0, "The exit code should be 0"
+                assert os.environ["ANSIBLE_LINT_NODEPS"] == "1"
 
                 found_file_counts_section = False
                 with (Path(output.name) / "report.txt").open("r") as f:
@@ -236,13 +237,15 @@ class TestMain(TestCase):
                             line = f.readline()
                             assert line == "yum                 2\n"
                             line = f.readline()
+                            assert line == "ec2                 1\n"
+                            line = f.readline()
                             assert line == "firewalld           1\n"
                             line = f.readline()
                             assert line == "meta                1\n"
                             line = f.readline()
                             assert line == "---------------------\n"
                             line = f.readline()
-                            assert line == "TOTAL               6\n"
+                            assert line == "TOTAL               7\n"
                             line = f.readline()
                             assert line == "---------------------\n"
 


### PR DESCRIPTION
<!--- Put corresponding issue link below. -->

Issue: https://issues.redhat.com/browse/AAP-19303

## Description

<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions. -->

Address areas of improvements on Ansible Content Parser found in the Jan 8 walk-through:

1. File extension of the output.  The postprocess code provided by IBM expects the training data to have the .jsonl extension while the current version of Ansible Content Parser genertes ftdata.json. We should change Ansible Content Parser to generate ftdata.jsonl.
2. The latest ansible-lint supports the environment variable `ANSIBLE_LINT_NODEPS` to ignore dependency errors, which can occur in content parser processing. Ansible Content Parser should set the variable.

## Testing

<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->

Unit tests are included.

### Steps to test

1. Build the Content Parser following [the instructions](https://github.com/ansible/ansible-content-parser/wiki/Build)
2. Run ansible-content-parser against Ansible code repositories to make sure if no function are broken.

### Scenarios tested

<!-- Describe the scenarios you've already manually verified, if applicable. -->
ansible-content-parser could generate
ftdata.jsonl file from [the ansible-examples repo](https://github.com/ansible/ansible-examples.git).