### PR TITLE
Do not perform Autofix when syntax check errors were found

### DIFF
--- a/src/ansible_content_parser/lint.py
+++ b/src/ansible_content_parser/lint.py
@@ -112,6 +112,9 @@ def ansiblelint_main(argv: list[str] | None = None) -> LintResult:
 
 def _syntax_check_errors_found(result: LintResult) -> bool:
     """Check if syntax check errors were found or not."""
-    return any(
+    rc = any(
         match.tag and match.tag.startswith("syntax-check") for match in result.matches
     )
+    if rc:
+        _logger.info("Autofix is suppressed as syntax-check errors are found.")
+    return rc

--- a/src/ansible_content_parser/lint.py
+++ b/src/ansible_content_parser/lint.py
@@ -69,7 +69,8 @@ def ansiblelint_main(argv: list[str] | None = None) -> LintResult:
         options.tags = options.tags.split(",")  # pragma: no cover
     result = get_matches(rules, options)
 
-    if options.write_list:
+    # Perform autofix if it is directed and no syntax check errors were found.
+    if options.write_list and not _syntax_check_errors_found(result):
         ruamel_safe_version = "0.17.26"
         from packaging.version import Version
         from ruamel.yaml import __version__ as ruamel_yaml_version_str
@@ -107,3 +108,10 @@ def ansiblelint_main(argv: list[str] | None = None) -> LintResult:
     return_code = app.report_outcome(result, mark_as_success=mark_as_success)
 
     return result, mark_as_success, return_code
+
+
+def _syntax_check_errors_found(result: LintResult) -> bool:
+    """Check if syntax check errors were found or not."""
+    return any(
+        match.tag and match.tag.startswith("syntax-check") for match in result.matches
+    )

--- a/src/ansible_content_parser/report.py
+++ b/src/ansible_content_parser/report.py
@@ -246,13 +246,20 @@ Output Directory      : {args.output}
     if json_file:
         with Path(json_file).open(encoding="utf-8") as f:
             result = json.load(f)
-            files = result["files"]
+            files_all = result["files"]
 
     last_json_file = json_file2 if json_file2 else json_file
     if last_json_file:
         with Path(last_json_file).open(encoding="utf-8") as f:
             result = json.load(f)
+            files = result["files"]
             excluded = result.get("excluded", [])
+
+            # If the "last" JSON file was the one obtained from the second run,
+            # it does not contain the information about the excluded files.
+            # If it is the case, add those files in the JSON file from the first run.
+            if last_json_file != json_file:
+                files += [f for f in files_all if f["filename"] in excluded]
 
         report += f"""
 


### PR DESCRIPTION
<!--- Put corresponding issue link below. -->

Issue: https://issues.redhat.com/browse/AAP-19351

## Description

<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions. -->
When the first ansible-lint run failed with syntax-check errors, Content Parser attempts to execute the second run.  However, the first run executes autofixes on files w/o ystax-check errors on the first run and ansible-lint runs against
different files from the original source. It is not how the code supposed to run.  We should suppress autofixes on the first run when syntax-check errors were found.

## Testing

<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->

### Steps to test

Build the Content Parser following [the instructions](https://github.com/ansible/ansible-content-parser/wiki/Build)
Run ansible-content-parser against Ansible code repositories to make sure if no function are broken.

### Scenarios tested

<!-- Describe the scenarios you've already manually verified, if applicable. -->
https://github.com/IBM/Ansible-OpenShift-Provisioning/ was used for the test