### PR TITLE
Fix 1.0.2 release build error

### DIFF
--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -1,3 +1,4 @@
+black == 23.7.0 # black-pre-commit-mirror 0.1.0 used in release build depends on this version
 coverage[toml] >= 6.4.4
 mypy # IDE support
 pytest >= 7.2.2

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -6,3 +6,4 @@ giturlparse
 sarif-tools
 sage-scan>=0.0.4
 ansible-risk-insight>=0.2.4
+black == 23.7.0 # Specify the same version as the one in requirements-test.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ ansible-core==2.16.3
 ansible-lint==6.22.2
 ansible-risk-insight==0.2.4
 attrs==23.2.0
-black==24.1.1
+black==23.7.0
 bracex==2.4
 certifi==2023.11.17
 cffi==1.16.0
@@ -68,7 +68,6 @@ subprocess-tee==0.4.1
 tabulate==0.9.0
 tomli==2.0.1
 treelib==1.7.0
-typing-extensions==4.9.0
 urllib3==2.1.0
 wcmatch==8.5
 yamllint==1.33.0


### PR DESCRIPTION
<!--- Put corresponding issue link below. -->

Issue: n/a

## Description

<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions. -->
The 1.0.2 release build failed due to the version mismatch error on the black library.  We had set a specific version in the build before but it was removed with [a recent commit](https://github.com/ansible/ansible-content-parser/commit/5b21333e8316d3a3fcfd9cdbac407998faf228bb). This PR basically restores that code.

## Testing

<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
Same as #36, i.e. execute ansible-content-parser against  https://github.com/ansible-collections/amazon.aws.git and verified that the training data set (ftdata.jsonl) was successfully created.

### Steps to test

1. Build and install the updated ansible-content-parser from the PR (ref: https://github.com/ansible/ansible-content-parser/wiki/Build)
2. Execute
```
ansible-content-parser https://github.com/ansible-collections/amazon.aws.git /tmp/out
```
3. Make sure `/tmp/out` directory contains ftdata.jsonl file.

### Scenarios tested

<!-- Describe the scenarios you've already manually verified, if applicable. -->

See the Steps to test section above.
