### PR TITLE
Removed fixed version specification for black and upgrade ansible-lint to 24.2.3

### DIFF
--- a/.config/requirements-dev.txt
+++ b/.config/requirements-dev.txt
@@ -1,4 +1,4 @@
-black == 23.7.0 # black-pre-commit-mirror 0.1.0 used in release build depends on this version
+black
 mypy
 pip-tools
 pre-commit

--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -1,4 +1,4 @@
-black == 23.7.0 # black-pre-commit-mirror 0.1.0 used in release build depends on this version
+black
 coverage[toml] >= 6.4.4
 mypy # IDE support
 pytest >= 7.2.2

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,9 +1,9 @@
 # Special order section for helping pip:
 will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
-ansible-lint>=6.22.2
+ansible-lint>=24.2.2
 GitPython
 giturlparse
 sarif-tools
 sage-scan>=0.0.4
 ansible-risk-insight>=0.2.4
-black == 23.7.0 # Specify the same version as the one in requirements-test.txt
+black

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -7,3 +7,4 @@ sarif-tools
 sage-scan>=0.0.4
 ansible-risk-insight>=0.2.4
 black
+pygit2

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,6 +1,6 @@
 # Special order section for helping pip:
 will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
-ansible-lint>=24.2.2
+ansible-lint>=24.2.3
 GitPython
 giturlparse
 sarif-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,10 @@
 ansible==9.1.0
 ansible-compat==4.1.11
 ansible-core==2.16.3
-ansible-lint==6.22.2
+ansible-lint==24.2.3
 ansible-risk-insight==0.2.4
 attrs==23.2.0
-black==23.7.0
+black==24.4.2
 bracex==2.4
 certifi==2023.11.17
 cffi==1.16.0
@@ -68,6 +68,7 @@ subprocess-tee==0.4.1
 tabulate==0.9.0
 tomli==2.0.1
 treelib==1.7.0
+typing-extensions==4.11.0
 urllib3==2.1.0
 wcmatch==8.5
 yamllint==1.33.0


### PR DESCRIPTION

<!--- Put corresponding issue link below. -->

Issue: [AAP-23227](https://issues.redhat.com/browse/AAP-23227)

## Description

<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions. -->

Update ansible-lint embedded in ansible-content-parser to its latest version (24.2.2).

ansible-lint 24.2.2 specifies black version `>=24.3.0`, which did not satisfy the condition `black==23.7.0` found in ansible-content-parser's requirements files. I needed to remove them to let upgrade ansible-lint.

## Testing

<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->

### Steps to test

1. Build and install the updated ansible-content-parser from the PR (ref: https://github.com/ansible/ansible-content-parser/wiki/Build)
2. Execute
```
ansible-content-parser https://github.com/ansible-collections/amazon.aws.git /tmp/out
```
3. Make sure `/tmp/out` directory contains ftdata.jsonl file.
### Scenarios tested

<!-- Describe the scenarios you've already manually verified, if applicable. -->

See the Steps to test section above.
